### PR TITLE
ADM remediating 3 vulnerable artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,19 +127,19 @@
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>tasks</artifactId>
-      <version>4.0</version>
+      <version>4.1</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>pmd</artifactId>
-      <version>3.1</version>
+      <version>3.2</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>warnings</artifactId>
-      <version>3.0</version>
+      <version>3.1</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Vulnerabilities: [Remediation Run Detect Stage](https://cloud.oracle.com/adm/remediationRecipes/ocid1.admremediationrecipe.oc1.eu-amsterdam-1.amaaaaaa3zyuybyaj3nqz3s2dveiws5ejndukoctehmkdfw5w6deq2taxdya/runs/ocid1.admremediationrun.oc1.eu-amsterdam-1.amaaaaaa3zyuybya73532xuhzabxadxh4fknll77h2qpq2bs7edbbladtrma/stages/DETECT)

* org.jenkins-ci.plugins:ci-game:1.27-SNAPSHOT
  * org.jenkins-ci.plugins:jacoco:1.0.18
    * GHSA-xj29-gfww-j67g
  * org.jenkins-ci.plugins:junit:1.0
    * GHSA-298r-5c48-7q2r
    * GHSA-4rj6-9pjh-882r
    * GHSA-64mj-3p92-589v
    * GHSA-ph74-8rgx-64c5
    * GHSA-x9gm-m8pp-54vx
  * org.jenkins-ci.plugins:structs:1.3
    * GHSA-xfx3-cr74-x3cv
  * org.jvnet.hudson.plugins:analysis-core:1.58
    * GHSA-3v9f-4vff-rx42
    * GHSA-9c2p-99pg-c4j9
    * GHSA-fg6g-52rg-vr9q
    * GHSA-vvfj-p4jf-j8rm
    * commons-beanutils:commons-beanutils:1.8.3
      * GHSA-6phf-73q6-gh87
      * GHSA-p66x-2cv9-qq3v
    * xerces:xercesImpl:2.11.0
      * CVE-2012-0881
      * CVE-2013-4002
      * CVE-2020-14338
      * CVE-2022-23437
      * GHSA-7j4h-8wpf-rqfh
      * GHSA-h65f-jvqw-m9fj
      * GHSA-vmqm-g3vh-847m
      * GHSA-w4jq-qh47-hvjq
  * org.jvnet.hudson.plugins:checkstyle:3.40
    * GHSA-jfj9-7j5w-6xgx
    * commons-beanutils:commons-beanutils:1.8.3
      * GHSA-6phf-73q6-gh87
      * GHSA-p66x-2cv9-qq3v
    * org.jvnet.hudson.plugins:analysis-core:1.58
      * GHSA-3v9f-4vff-rx42
      * GHSA-9c2p-99pg-c4j9
      * GHSA-fg6g-52rg-vr9q
      * GHSA-vvfj-p4jf-j8rm
    * xerces:xercesImpl:2.11.0
      * CVE-2012-0881
      * CVE-2013-4002
      * CVE-2020-14338
      * CVE-2022-23437
      * GHSA-7j4h-8wpf-rqfh
      * GHSA-h65f-jvqw-m9fj
      * GHSA-vmqm-g3vh-847m
      * GHSA-w4jq-qh47-hvjq
  * org.jvnet.hudson.plugins:findbugs:4.50
    * GHSA-24g8-35x9-fv8r
    * commons-beanutils:commons-beanutils:1.8.3
      * GHSA-6phf-73q6-gh87
      * GHSA-p66x-2cv9-qq3v
    * org.jvnet.hudson.plugins.findbugs:library:2.0.1
      * GHSA-pr9h-g7p7-rrqh
    * org.jvnet.hudson.plugins:analysis-core:1.58
      * GHSA-3v9f-4vff-rx42
      * GHSA-9c2p-99pg-c4j9
      * GHSA-fg6g-52rg-vr9q
      * GHSA-vvfj-p4jf-j8rm
    * xerces:xercesImpl:2.11.0
      * CVE-2012-0881
      * CVE-2013-4002
      * CVE-2020-14338
      * CVE-2022-23437
      * GHSA-7j4h-8wpf-rqfh
      * GHSA-h65f-jvqw-m9fj
      * GHSA-vmqm-g3vh-847m
      * GHSA-w4jq-qh47-hvjq
  * org.jvnet.hudson.plugins:pmd:3.1
    * GHSA-687x-269m-7cv9
    * com.jcraft:jsch:0.1.27
      * GHSA-q446-82vq-w674
    * commons-beanutils:commons-beanutils:1.8.3
      * GHSA-6phf-73q6-gh87
      * GHSA-p66x-2cv9-qq3v
    * commons-httpclient:commons-httpclient:3.1-rc1
      * GHSA-3832-9276-x7gf
    * dom4j:dom4j:1.6.1
      * GHSA-6pcc-3rfx-4gpm
      * GHSA-hwj3-m3p6-hj38
    * org.apache.maven:maven-core:2.0.9
      * GHSA-2f88-5hg8-9x2x
    * org.codehaus.plexus:plexus-utils:1.5.1
      * GHSA-8vhq-qq4p-grq3
      * GHSA-g6ph-x5wf-g337
      * GHSA-jcwr-x25h-x5fh
    * org.jvnet.hudson.plugins:analysis-core:1.58
      * GHSA-3v9f-4vff-rx42
      * GHSA-9c2p-99pg-c4j9
      * GHSA-fg6g-52rg-vr9q
      * GHSA-vvfj-p4jf-j8rm
    * xalan:xalan:2.6.0
      * GHSA-9339-86wc-4qgf
      * GHSA-rc2w-r4jq-7pfx
    * xerces:xercesImpl:2.11.0
      * CVE-2012-0881
      * CVE-2013-4002
      * CVE-2020-14338
      * CVE-2022-23437
      * GHSA-7j4h-8wpf-rqfh
      * GHSA-h65f-jvqw-m9fj
      * GHSA-vmqm-g3vh-847m
      * GHSA-w4jq-qh47-hvjq
  * org.jvnet.hudson.plugins:tasks:4.0
    * com.jcraft:jsch:0.1.27
      * GHSA-q446-82vq-w674
    * commons-beanutils:commons-beanutils:1.8.3
      * GHSA-6phf-73q6-gh87
      * GHSA-p66x-2cv9-qq3v
    * commons-httpclient:commons-httpclient:3.1-rc1
      * GHSA-3832-9276-x7gf
    * dom4j:dom4j:1.6.1
      * GHSA-6pcc-3rfx-4gpm
      * GHSA-hwj3-m3p6-hj38
    * org.apache.maven:maven-core:2.0.9
      * GHSA-2f88-5hg8-9x2x
    * org.codehaus.plexus:plexus-utils:1.5.1
      * GHSA-8vhq-qq4p-grq3
      * GHSA-g6ph-x5wf-g337
      * GHSA-jcwr-x25h-x5fh
    * org.jvnet.hudson.plugins:analysis-core:1.58
      * GHSA-3v9f-4vff-rx42
      * GHSA-9c2p-99pg-c4j9
      * GHSA-fg6g-52rg-vr9q
      * GHSA-vvfj-p4jf-j8rm
    * xalan:xalan:2.6.0
      * GHSA-9339-86wc-4qgf
      * GHSA-rc2w-r4jq-7pfx
    * xerces:xercesImpl:2.11.0
      * CVE-2012-0881
      * CVE-2013-4002
      * CVE-2020-14338
      * CVE-2022-23437
      * GHSA-7j4h-8wpf-rqfh
      * GHSA-h65f-jvqw-m9fj
      * GHSA-vmqm-g3vh-847m
      * GHSA-w4jq-qh47-hvjq
  * org.jvnet.hudson.plugins:warnings:3.0
    * GHSA-mmrv-3cqg-hpf9
    * GHSA-p498-rpcw-3578
    * GHSA-q564-vvx8-9388
    * com.jcraft:jsch:0.1.27
      * GHSA-q446-82vq-w674
    * commons-beanutils:commons-beanutils:1.8.3
      * GHSA-6phf-73q6-gh87
      * GHSA-p66x-2cv9-qq3v
    * commons-httpclient:commons-httpclient:3.1-rc1
      * GHSA-3832-9276-x7gf
    * dom4j:dom4j:1.6.1
      * GHSA-6pcc-3rfx-4gpm
      * GHSA-hwj3-m3p6-hj38
    * org.apache.maven:maven-core:2.0.9
      * GHSA-2f88-5hg8-9x2x
    * org.codehaus.plexus:plexus-utils:1.5.1
      * GHSA-8vhq-qq4p-grq3
      * GHSA-g6ph-x5wf-g337
      * GHSA-jcwr-x25h-x5fh
    * org.jvnet.hudson.plugins:analysis-core:1.58
      * GHSA-3v9f-4vff-rx42
      * GHSA-9c2p-99pg-c4j9
      * GHSA-fg6g-52rg-vr9q
      * GHSA-vvfj-p4jf-j8rm
    * xalan:xalan:2.6.0
      * GHSA-9339-86wc-4qgf
      * GHSA-rc2w-r4jq-7pfx
    * xerces:xercesImpl:2.11.0
      * CVE-2012-0881
      * CVE-2013-4002
      * CVE-2020-14338
      * CVE-2022-23437
      * GHSA-7j4h-8wpf-rqfh
      * GHSA-h65f-jvqw-m9fj
      * GHSA-vmqm-g3vh-847m
      * GHSA-w4jq-qh47-hvjq

## Dependencies upgraded: [Remediation Run Recommend Stage](https://cloud.oracle.com/adm/remediationRecipes/ocid1.admremediationrecipe.oc1.eu-amsterdam-1.amaaaaaa3zyuybyaj3nqz3s2dveiws5ejndukoctehmkdfw5w6deq2taxdya/runs/ocid1.admremediationrun.oc1.eu-amsterdam-1.amaaaaaa3zyuybya73532xuhzabxadxh4fknll77h2qpq2bs7edbbladtrma/stages/RECOMMEND)

* org.jvnet.hudson.plugins:pmd:3.1 -> 3.2
* org.jvnet.hudson.plugins:tasks:4.0 -> 4.1
* org.jvnet.hudson.plugins:warnings:3.0 -> 3.1

Auto-merge is disabled.